### PR TITLE
Adapt to cakePHP 4.1

### DIFF
--- a/src/Model/Entity/Notification.php
+++ b/src/Model/Entity/Notification.php
@@ -87,10 +87,10 @@ class Notification extends Entity
     {
         $templates = Configure::read('Notifier.templates');
 
-        if (array_key_exists($this->_properties['template'], $templates)) {
-            $template = $templates[$this->_properties['template']];
+        if (array_key_exists($this->get('template'), $templates)) {
+            $template = $templates[$this->get('template')];
 
-            $vars = json_decode($this->_properties['vars'], true);
+            $vars = json_decode($this->get('vars'), true);
 
             return Text::insert($template['title'], $vars);
         }
@@ -110,10 +110,10 @@ class Notification extends Entity
     {
         $templates = Configure::read('Notifier.templates');
 
-        if (array_key_exists($this->_properties['template'], $templates)) {
-            $template = $templates[$this->_properties['template']];
+        if (array_key_exists($this->get('template'), $templates)) {
+            $template = $templates[$this->get('template')];
 
-            $vars = json_decode($this->_properties['vars'], true);
+            $vars = json_decode($this->get('vars'), true);
 
             return Text::insert($template['body'], $vars);
         }
@@ -129,7 +129,7 @@ class Notification extends Entity
      */
     protected function _getUnread()
     {
-        if ($this->_properties['state'] === 1) {
+        if ($this->get('state') === 1) {
             return true;
         }
         return false;
@@ -144,7 +144,7 @@ class Notification extends Entity
      */
     protected function _getRead()
     {
-        if ($this->_properties['state'] === 0) {
+        if ($this->get('state') === 0) {
             return true;
         }
         return false;

--- a/src/Model/Table/NotificationsTable.php
+++ b/src/Model/Table/NotificationsTable.php
@@ -53,7 +53,7 @@ class NotificationsTable extends Table
      *
      * @return \Cake\Validation\Validator
      */
-    public function validationDefault(Validator $validator)
+    public function validationDefault(Validator $validator): Validator
     {
         $validator
             ->add('id', 'valid', ['rule' => 'numeric'])


### PR DESCRIPTION
by using the get() method instead of $_properties and by adding a return type declaration, on the model.